### PR TITLE
fix: link regex in markdown

### DIFF
--- a/src/js/markdownRules.js
+++ b/src/js/markdownRules.js
@@ -31,7 +31,7 @@ export function parseMarkdown(markdownText) {
 
     // Handle links
     {
-      regex: /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+      regex: /\[([^\]]+)\]\((https?:\/\/[^\s)]+|\S+)\)/g,
       replacement:
         '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>',
     },

--- a/src/styles/stylesheet.css
+++ b/src/styles/stylesheet.css
@@ -634,3 +634,7 @@ body, header, main.content > button {
   visibility: visible;
   opacity: 1;
 }
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
### Description
- The regex to match 'links' in the markdown cell was missing a '\' escape character due to strict eslint checks. Fixed it to make the links work.

### Related Issues
- Link any related issues here (e.g., `Fixes #123`).

### Type of Change
- [x ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please specify):

### Testing Details
- Explain the tests performed, or attach screenshots of results if applicable.

### Checklist
- [ x] Code follows the style guide.
- [ x] I have performed a self-review of my code.
- [ ] Documentation has been updated (if necessary).
- [ ] Tests have been added or updated.

### Additional Notes
- Trivial change
